### PR TITLE
Add refs argument do diff command

### DIFF
--- a/spr/src/commands/diff.rs
+++ b/spr/src/commands/diff.rs
@@ -6,6 +6,7 @@
  */
 
 use std::iter::zip;
+use std::collections::HashSet;
 
 use crate::{
     error::{add_error, Error, Result, ResultExt},
@@ -41,10 +42,52 @@ pub struct DiffOptions {
     #[clap(long, short = 'm')]
     message: Option<String>,
 
+    /// Which commits in the branch should be created/updated. This can be a
+    /// revspec such as HEAD~4..HEAD~1 or just one commit like HEAD~7.
+    #[clap(long, short = 'r')]
+    refs: Option<String>,
+
     /// Submit this commit as if it was cherry-picked on master. Do not base it
     /// on any intermediate changes between the master branch and this commit.
     #[clap(long)]
     cherry_pick: bool,
+}
+
+fn get_oids(refs: &String, repo: &git2::Repository) -> Result<HashSet<Oid>> {
+    // refs might be a single (eg 012345abc or HEAD) or a range (HEAD~4..HEAD~2)
+    let revspec = repo.revparse(&refs)?;
+    if revspec.mode().contains(git2::RevparseMode::MERGE_BASE) {
+        // this is ok, as other code doesn't handle merges
+        return Err(Error::new("Unable to cope with merge_base --refs"));
+    } else if revspec.mode().contains(git2::RevparseMode::SINGLE) {
+        // simple case, just return the id
+        return Ok(HashSet::from([revspec.from().unwrap().id()]));
+    } else if revspec.mode().contains(git2::RevparseMode::RANGE) {
+        // If it's a range we have to walk from `from` to `to` grabbing oids
+        let mut to = revspec.to().ok_or(Error::new("Unexpectedly no to id in range"))?.id();
+        let from = revspec.from().ok_or(Error::new("Unexpectedly no from id in range"))?.id();
+        let mut ret = HashSet::new();
+        loop {
+            ret.insert(to);
+            if to == from {
+                // finished the walk
+                break;
+            }
+            let commit_to = repo.find_commit(to)?;
+            let mut oid_iter = commit_to.parent_ids();
+            let next_oid = oid_iter.next();
+            if let Some(_) = oid_iter.next() {
+                return Err(Error::new("Unexpectedly had multiple parents for commit"));
+            }
+            match next_oid {
+                None => return Err(Error::new("Unexpectedly no parent id for commit")),
+                Some(id) => to = id,
+            }
+        }
+        return Ok(ret);
+    } else {
+        return Err(Error::new("Unable to cope with this type of revspec for --refs"));
+    }
 }
 
 pub async fn diff(
@@ -70,7 +113,11 @@ pub async fn diff(
         return result;
     };
 
-    if !opts.all {
+    if let Some(refs) = &opts.refs {
+        // Restrict the prepared commits to the given refset
+        let revs = get_oids(&refs, &git.repo())?;
+        prepared_commits.retain(|f| revs.contains(&f.oid));
+    } else if !opts.all {
         // Remove all prepared commits from the vector but the last. So, if
         // `--all` is not given, we only operate on the HEAD commit.
         prepared_commits.drain(0..prepared_commits.len() - 1);


### PR DESCRIPTION
It is often useful to only update the PR further up the stack.

Eg if you have a stack of 4 but made changes to the second one only you could run: `spr diff -r HEAD~3`.
Alternatively if you made changes to all but this one (for example because you haven't made a PR from it): `spr diff -r HEAD~4..HEAD~1`