### PR TITLE
Update git2-ext dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,8 +540,9 @@ dependencies = [
 
 [[package]]
 name = "git2-ext"
-version = "0.6.2"
-source = "git+https://github.com/mhammerly/git2-ext.git?rev=115a912b7b89d91c03d1e52e0d39b60adb04dde6#115a912b7b89d91c03d1e52e0d39b60adb04dde6"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4902819113d2dad808b4695e535ea808cdebc152f54bce94ed878ac24a6afd01"
 dependencies = [
  "bstr",
  "git2",

--- a/spr/Cargo.toml
+++ b/spr/Cargo.toml
@@ -16,7 +16,7 @@ dialoguer = "^0.11.0"
 futures = "^0.3.31"
 futures-lite = "^2.6.0"
 git2 = { version = "^0.20.1", default-features = false }
-git2-ext ={ git="https://github.com/mhammerly/git2-ext.git", rev = "115a912b7b89d91c03d1e52e0d39b60adb04dde6" }
+git2-ext = "^0.6.3"
 graphql_client = "^0.14.0"
 indoc = "^2.0.6"
 lazy-regex = "^3.4.1"


### PR DESCRIPTION
The latest git2-ext release is compatible with an up-to-date git2
dependency
