### PR TITLE
fix: Use correct path for init repos

### DIFF
--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -166,7 +166,7 @@ pub async fn init() -> Result<()> {
 
     let github_repo_info = octocrab
         .get::<octocrab::models::Repository, _, _>(
-            format!("repos/{}", &github_repo),
+            format!("/repos/{}", &github_repo),
             None::<&()>,
         )
         .await?;


### PR DESCRIPTION
Honestly I'm not sure why this is necessary, the code this PR modifies is ancient. That said, without this, I get:

```console
$ cargo run -q -- init
.. snip ..
  ❓  What's the name of the GitHub repository. Please enter 'OWNER/REPOSITORY' (basically the bit that follow 'github.com/' in the address.)
GitHub repository: quodlibetor/spr
  🛑  Getting github repo info
  caused by:  Uri
  caused by:  invalid format
```