### PR TITLE
Add leading slash to octocrab routes

### DIFF
--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -166,7 +166,7 @@ pub async fn init() -> Result<()> {
 
     let github_repo_info = octocrab
         .get::<octocrab::models::Repository, _, _>(
-            format!("repos/{}", &github_repo),
+            format!("/repos/{}", &github_repo),
             None::<&()>,
         )
         .await?;

--- a/src/github.rs
+++ b/src/github.rs
@@ -136,7 +136,7 @@ impl GitHub {
 
     pub async fn get_github_user(login: String) -> Result<UserWithName> {
         octocrab::instance()
-            .get::<UserWithName, _, _>(format!("users/{}", login), None::<&()>)
+            .get::<UserWithName, _, _>(format!("/users/{}", login), None::<&()>)
             .await
             .map_err(Error::from)
     }


### PR DESCRIPTION
The missing leading slash causes Uri errors to be thrown.

Fixes https://github.com/spacedentist/spr/issues/227
